### PR TITLE
Allow external configuration file

### DIFF
--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/util/JedisTool.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/util/JedisTool.java
@@ -16,15 +16,20 @@
 
 package org.hibernate.cache.redis.util;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Properties;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.hibernate.cache.redis.jedis.JedisClient;
 import org.hibernate.cfg.Environment;
+
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.Protocol;
-
-import java.io.InputStream;
-import java.util.Properties;
 
 /**
  * Jedis Helper class
@@ -36,6 +41,7 @@ import java.util.Properties;
 public final class JedisTool {
 
     public static final String EXPIRY_PROPERTY_PREFIX = "redis.expiryInSeconds.";
+    private static final String FILE_URL_PREFIX = "file:";
     private static Properties cacheProperties = null;
 
     private JedisTool() { }
@@ -80,12 +86,22 @@ public final class JedisTool {
         Properties cacheProps = new Properties();
         String cachePath = props.getProperty(Environment.CACHE_PROVIDER_CONFIG,
                                              "hibernate-redis.properties");
+
+        InputStream is = null;
         try {
             log.info("Loading cache properties... path=[{}]", cachePath);
-            InputStream is = JedisTool.class.getClassLoader().getResourceAsStream(cachePath);
+            if (cachePath.startsWith(FILE_URL_PREFIX)) {
+                is = new FileInputStream(new File(new URI(cachePath)));
+            } else {
+                is = JedisTool.class.getClassLoader().getResourceAsStream(cachePath);
+            }
             cacheProps.load(is);
         } catch (Exception e) {
             log.warn("Fail to load cache properties. cachePath=" + cachePath, e);
+        } finally {
+            if (is != null) {
+                try {is.close();} catch (Exception e) {}
+            }
         }
         return cacheProps;
     }


### PR DESCRIPTION
Allow external configuration file #17

Calling the above

InputStream is = JedisTool.class.getClassLoader().getResourceAsStream(cachePath);

forces the configuration hibernate-redis.properties to be inside the classpath. 
Would be great if it was possible to define the configuration file anywhere the system.

If configuration starts with file: then use the absolute file path
