### PR TITLE
Implementation of a cache key customizer mecanism.

### DIFF
--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/jedis/JedisCacheKeyCustomizer.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/jedis/JedisCacheKeyCustomizer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014 dyorgio.nascimento.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hibernate.cache.redis.jedis;
+
+/**
+ * A interface to customize cache key. (multi-tenancy cache, other stuffs)
+ * @author dyorgio.nascimento
+ */
+public interface JedisCacheKeyCustomizer {
+    
+    Object customizeKey(Object key);
+}


### PR DESCRIPTION
Necessary to isolate second level and query caches in a multi-tenancy env.

ex: 
```java
return key + "#" + tenantId;
```