### PR TITLE
Read all the properties in the factory. 

### DIFF
--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/AbstractRedisRegionFactory.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/AbstractRedisRegionFactory.java
@@ -52,7 +52,7 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
      */
     protected Settings settings;
 
-    protected final Properties props;
+    protected Properties props;
 
     protected final RedisAccessStrategyFactory accessStrategyFactory = new RedisAccessStrategyFactoryImpl();
 

--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/RedisRegionFactory.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/RedisRegionFactory.java
@@ -41,9 +41,10 @@ public class RedisRegionFactory extends AbstractRedisRegionFactory {
         log.info("starting RedisRegionFactory...");
 
         this.settings = settings;
+        this.props = JedisTool.loadCacheProperties(properties);
         try {
             if (redis == null) {
-                this.redis = JedisTool.createJedisClient(props);
+                this.redis = JedisTool.createJedisClient(this.props);
                 manageExpiration(redis);
             }
             log.info("RedisRegionFactory is started");

--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/SingletonRedisRegionFactory.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/SingletonRedisRegionFactory.java
@@ -45,9 +45,10 @@ public class SingletonRedisRegionFactory extends AbstractRedisRegionFactory {
         log.info("starting SingletonRedisRegionFactory...");
 
         this.settings = settings;
+        this.props = JedisTool.loadCacheProperties(properties);
         try {
             if (redis == null) {
-                this.redis = JedisTool.createJedisClient(props);
+                this.redis = JedisTool.createJedisClient(this.props);
                 manageExpiration(redis);
             }
             ReferenceCount.incrementAndGet();

--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/regions/RedisDataRegion.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/regions/RedisDataRegion.java
@@ -77,8 +77,7 @@ public abstract class RedisDataRegion implements Region {
                 Integer.decode(props.getProperty(CACHE_LOCK_TIMEOUT_PROPERTY,
                                                  String.valueOf(DEFAULT_CACHE_LOCK_TIMEOUT)));
 
-        int defaultExpires = Integer.decode(JedisTool.getProperty(EXPIRE_IN_SECONDS, "120"));
-        this.expireInSeconds = JedisTool.getExpireInSeconds(name, defaultExpires);
+        this.expireInSeconds = JedisTool.getExpireInSeconds(props, name);
     }
 
     /**


### PR DESCRIPTION
JedisTool no longer stores state instead is a helper for reading properties.

The initial properties are now merged with those found in cache_provide_config allowing greater flexibility of how the RegionFactories are configured.

Fixes #32 