### PR TITLE
Load the JpaProperties as the default value for hibernate-redis confi…

### DIFF
--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/util/JedisTool.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/util/JedisTool.java
@@ -81,7 +81,7 @@ public final class JedisTool {
     }
 
     private static Properties loadCacheProperties(final Properties props) {
-        Properties cacheProps = new Properties();
+        Properties cacheProps = new Properties(props);
         String cachePath = props.getProperty(Environment.CACHE_PROVIDER_CONFIG,
                                              "hibernate-redis.properties");
 


### PR DESCRIPTION
By default, hibernate-redis only loads properties from hibernate-redis.properties. But sometimes we want to reuse the configuration from other configurations.

e.g. I'd like to reuse the following configurations:

```xml
    <bean id="entityManager" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
        <property name="dataSource" ref="dataSource"/>
        <property name="packagesToScan">
            <list>
                <value>cn.irenshi.meta.dto.*.mysql</value>
            </list>
        </property>
        <property name="jpaVendorAdapter" ref="jpaVendorAdapter"/>
        <property name="jpaProperties">
            <props>
                <prop key="connection.autoReconnect">true</prop>
                <prop key="connection.autoReconnectForPools">true</prop>
                <prop key="connection.is-connection-validation-required">true</prop>
                <prop key="hibernate.hbm2ddl.auto">${datasource.hibernate.hbm2ddl.auto:update}</prop>
                <prop key="hibernate.dialect">${datasource.hibernate.dialect:org.hibernate.dialect.MySQL5InnoDBDialect}</prop>

                <!-- Redis cache for hibernate -->
                <prop key="hibernate.cache.use_second_level_cache">true</prop>
                <prop key="hibernate.cache.use_query_cache">true</prop>
                <prop key="hibernate.cache.region.factory_class">org.hibernate.cache.redis.SingletonRedisRegionFactory</prop>
                <prop key="hibernate.cache.region_prefix">hibernate</prop>
                <prop key="redis.host">${redis.address}</prop>
                <prop key="redis.port">${redis.port:6379}</prop>
                <prop key="redis.password">${redis.auth:somepass}</prop>
                <prop key="hibernate.cache.use_structured_entries">true</prop>
            </props>
        </property>
    </bean>
```