### PR TITLE
Fixing ERR CROSSSLOT Keys in request don't hash to the same slot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ generatedTest
 !maven-wrapper.properties
 /hibernate-redis/dependency-reduced-pom.xml
 **/pom.xml.versionsBackup
+release.properties

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ generatedTest
 !maven-wrapper.jar
 !maven-wrapper.properties
 /hibernate-redis/dependency-reduced-pom.xml
+**/pom.xml.versionsBackup

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 hibernate-redis  
 ===============
+
+(About this fork): Created because hibernate-redis has some problems with removing cache entries when configured with a cluster (CROSSLOT issues). So this fork uses redisson PRO and uses the built in "cache-like" features of redis. Configured with "maxmemory 1GB" and "maxmemory-policy allkeys-lru" in the redis.conf. The caveat of this is that it's impossible to configure TTL for cache regions, the last used entry will be flushed when redis memory gets full. As redisson PRO costs, this fork releases against an internal maven server (nexus). To release use: mvn -Darguments=-Dredisson.pro.key="key_from_redisson_pro_email" release:prepare release:perform.
+
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.debop/hibernate-redis.svg)](https://repo1.maven.org/maven2/com/github/debop/hibernate-redis) [![Build Status](https://travis-ci.org/debop/hibernate-redis.png)](https://travis-ci.org/debop/hibernate-redis)
 
 [hibernate][1] (4.x, 5.1.x, 5.2.x) 2nd level cache provider using redis server 3.x. with [Redisson][2] 2.3.x
@@ -86,13 +89,6 @@ sample for hibernate-redis.properties
 
  # Redisson configuration file
  redisson-config=conf/redisson.yaml
-
- # Cache Expiry settings
- # 'hibernate' is second cache prefix
- # 'common', 'account' is actual region name
- redis.expiryInSeconds.default=120
- redis.expiryInSeconds.hibernate.common=0
- redis.expiryInSeconds.hibernate.account=1200
 ```
 
 sample for Redisson configuration (see [more samples](https://github.com/mrniko/redisson/wiki/2.-Configuration) )
@@ -101,32 +97,35 @@ sample for Redisson configuration (see [more samples](https://github.com/mrniko/
 # redisson configuration for redis servers
 # see : https://github.com/mrniko/redisson/wiki/2.-Configuration
 
-singleServerConfig:
+clusterServersConfig:
   idleConnectionTimeout: 10000
   pingTimeout: 1000
-  connectTimeout: 1000
-  timeout: 1000
-  retryAttempts: 1
-  retryInterval: 1000
+  connectTimeout: 10000
+  timeout: 3000
+  retryAttempts: 3
+  retryInterval: 1500
   reconnectionTimeout: 3000
-  failedAttempts: 1
+  failedAttempts: 3
   password: null
   subscriptionsPerConnection: 5
   clientName: null
-  address:
+  loadBalancer: !<org.redisson.connection.balancer.RoundRobinLoadBalancer> {}
+  slaveSubscriptionConnectionMinimumIdleSize: 1
+  slaveSubscriptionConnectionPoolSize: 50
+  slaveConnectionMinimumIdleSize: 5
+  slaveConnectionPoolSize: 250
+  masterConnectionMinimumIdleSize: 5
+  masterConnectionPoolSize: 250
+  readMode: "SLAVE"
+  nodeAddresses:
   - "//127.0.0.1:6379"
-  subscriptionConnectionMinimumIdleSize: 1
-  subscriptionConnectionPoolSize: 25
-  connectionMinimumIdleSize: 5
-  connectionPoolSize: 100
-  database: 0
-  dnsMonitoring: false
-  dnsMonitoringInterval: 5000
+  - "//127.0.0.1:6381"
+  - "//127.0.0.1:6382"
+  scanInterval: 1000
 threads: 0
-# Codec
+nettyThreads: 0
 codec: !<org.redisson.codec.SnappyCodec> {}
 useLinuxNativeEpoll: false
-eventLoopGroup: null
 ```
 
 ### Hibernate configuration via Spring [Application property files](http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-application-property-files)
@@ -144,10 +143,6 @@ spring.jpa.properties.hibernate.cache.use_structured_entries=true
 spring.jpa.properties.hibernate.generate_statistics=true
 
 spring.jpa.properties.redisson-config=classpath:conf/redisson.yaml
-
-spring.jpa.properties.redis.expiryInSeconds.default=120
-spring.jpa.properties.redis.expiryInSeconds.hibernate.common=0
-spring.jpa.properties.redis.expiryInSeconds.hibernate.account=1200
 ```
 
 ### Setup hibernate entity to use cache

--- a/hibernate-examples/pom.xml
+++ b/hibernate-examples/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.4-INTERNAL-SNAPSHOT</version>
+    <version>2.3.4-INTERNAL</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate-examples/pom.xml
+++ b/hibernate-examples/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.3-SNAPSHOT</version>
+    <version>2.3.3-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate-examples/pom.xml
+++ b/hibernate-examples/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.3-INTERNAL-SNAPSHOT</version>
+    <version>2.3.4-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate-examples/pom.xml
+++ b/hibernate-examples/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.4-INTERNAL</version>
+    <version>2.3.5-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate-examples/src/test/resources/conf/redisson.yaml
+++ b/hibernate-examples/src/test/resources/conf/redisson.yaml
@@ -1,29 +1,32 @@
 # redisson configuration for redis servers
 # see : https://github.com/mrniko/redisson/wiki/2.-Configuration
 
-singleServerConfig:
+clusterServersConfig:
   idleConnectionTimeout: 10000
   pingTimeout: 1000
-  connectTimeout: 1000
-  timeout: 1000
+  connectTimeout: 10000
+  timeout: 3000
   retryAttempts: 1
-  retryInterval: 1000
+  retryInterval: 1500
   reconnectionTimeout: 3000
   failedAttempts: 1
   password: null
   subscriptionsPerConnection: 5
   clientName: null
-  address:
+  loadBalancer: !<org.redisson.connection.balancer.RoundRobinLoadBalancer> {}
+  slaveSubscriptionConnectionMinimumIdleSize: 1
+  slaveSubscriptionConnectionPoolSize: 50
+  slaveConnectionMinimumIdleSize: 5
+  slaveConnectionPoolSize: 250
+  masterConnectionMinimumIdleSize: 5
+  masterConnectionPoolSize: 250
+  readMode: "SLAVE"
+  nodeAddresses:
   - "//127.0.0.1:6379"
-  subscriptionConnectionMinimumIdleSize: 1
-  subscriptionConnectionPoolSize: 25
-  connectionMinimumIdleSize: 5
-  connectionPoolSize: 100
-  database: 0
-  dnsMonitoring: false
-  dnsMonitoringInterval: 5000
+  - "//127.0.0.1:6381"
+  - "//127.0.0.1:6382"
+  scanInterval: 1000
 threads: 0
-# Codec
+nettyThreads: 0
 codec: !<org.redisson.codec.SnappyCodec> {}
 useLinuxNativeEpoll: false
-eventLoopGroup: null

--- a/hibernate-redis-client/conf/hibernate-redis.properties
+++ b/hibernate-redis-client/conf/hibernate-redis.properties
@@ -20,13 +20,3 @@
 # if you want outside file (use file:conf/redisson.yaml)
 #
 redisson-config=classpath:conf/redisson.yaml
-#
-# Cache Expiry settings
-# 'hibernate' is second cache prefix
-# 'common', 'account' is actual region name
-#
-# default = 120 seconds (2 minutes) (see RedisCacheUtil.DEFAULT_EXPIRY_IN_SECONDS)
-#
-redis.expiryInSeconds.default=360
-redis.expiryInSeconds.hibernate.common=0
-redis.expiryInSeconds.hibernate.account=1200

--- a/hibernate-redis-client/conf/redisson.yaml
+++ b/hibernate-redis-client/conf/redisson.yaml
@@ -1,28 +1,32 @@
 # redisson configuration for redis servers
 # see : https://github.com/mrniko/redisson/wiki/2.-Configuration
 
-singleServerConfig:
+clusterServersConfig:
   idleConnectionTimeout: 10000
   pingTimeout: 1000
-  connectTimeout: 1000
-  timeout: 1000
-  retryAttempts: 1
-  retryInterval: 1000
+  connectTimeout: 10000
+  timeout: 3000
+  retryAttempts: 3
+  retryInterval: 1500
   reconnectionTimeout: 3000
-  failedAttempts: 1
+  failedAttempts: 3
   password: null
   subscriptionsPerConnection: 5
   clientName: null
-  address:
+  loadBalancer: !<org.redisson.connection.balancer.RoundRobinLoadBalancer> {}
+  slaveSubscriptionConnectionMinimumIdleSize: 1
+  slaveSubscriptionConnectionPoolSize: 50
+  slaveConnectionMinimumIdleSize: 5
+  slaveConnectionPoolSize: 250
+  masterConnectionMinimumIdleSize: 5
+  masterConnectionPoolSize: 250
+  readMode: "SLAVE"
+  nodeAddresses:
   - "//127.0.0.1:6379"
-  subscriptionConnectionMinimumIdleSize: 1
-  subscriptionConnectionPoolSize: 25
-  connectionMinimumIdleSize: 5
-  connectionPoolSize: 100
-  database: 0
-  dnsMonitoring: false
-  dnsMonitoringInterval: 5000
+  - "//127.0.0.1:6381"
+  - "//127.0.0.1:6382"
+  scanInterval: 1000
 threads: 0
+nettyThreads: 0
 codec: !<org.redisson.codec.SnappyCodec> {}
 useLinuxNativeEpoll: false
-eventLoopGroup: null

--- a/hibernate-redis-client/pom.xml
+++ b/hibernate-redis-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.4-INTERNAL-SNAPSHOT</version>
+    <version>2.3.4-INTERNAL</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate-redis-client/pom.xml
+++ b/hibernate-redis-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.3-INTERNAL-SNAPSHOT</version>
+    <version>2.3.4-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate-redis-client/pom.xml
+++ b/hibernate-redis-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.4-INTERNAL</version>
+    <version>2.3.5-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate-redis-client/pom.xml
+++ b/hibernate-redis-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.3-SNAPSHOT</version>
+    <version>2.3.3-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -34,6 +34,7 @@
     <dependency>
       <groupId>org.redisson</groupId>
       <artifactId>redisson</artifactId>
+      <classifier>pro</classifier>
     </dependency>
 
     <dependency>

--- a/hibernate-redis-client/src/main/java/org/hibernate/cache/redis/client/RedisClient.java
+++ b/hibernate-redis-client/src/main/java/org/hibernate/cache/redis/client/RedisClient.java
@@ -22,6 +22,7 @@ import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.cache.redis.util.RedisCacheUtil;
+import org.redisson.api.RClusteredMap;
 import org.redisson.api.RMapCache;
 import org.redisson.api.RScript;
 import org.redisson.api.RedissonClient;
@@ -49,22 +50,11 @@ public class RedisClient {
   @Getter
   private final transient RedissonClient redisson;
 
-  @Getter
-  @Setter
-  private int expiryInSeconds;
-
-  public RedisClient(RedissonClient redisson) {
-    this(redisson, RedisCacheUtil.DEFAULT_EXPIRY_IN_SECONDS);
-  }
-
   @SneakyThrows
-  public RedisClient(@NonNull RedissonClient redisson, int expiryInSeconds) {
-    log.trace("RedisClient created. config={}, expiryInSeconds={}", redisson.getConfig().toJSON(), expiryInSeconds);
+  public RedisClient(@NonNull RedissonClient redisson) {
+    log.trace("RedisClient created. config={}", redisson.getConfig().toJSON());
     this.redisson = redisson;
 
-    if (expiryInSeconds >= 0) {
-      this.expiryInSeconds = expiryInSeconds;
-    }
   }
 
   public long nextTimestamp(final List<Object> keys) {
@@ -89,10 +79,6 @@ public class RedisClient {
     return cacheItem;
   }
 
-  public boolean isExpired(final String region, final Object key) {
-    return exists(region, key);
-  }
-
   public Set<Object> keysInRegion(final String region) {
     return getCache(region).keySet();
   }
@@ -107,23 +93,16 @@ public class RedisClient {
   }
 
   public void set(final String region, final Object key, Object value) {
-    set(region, key, value, expiryInSeconds);
-  }
+    log.trace("set cache item. region={}, key={}",
+              region, key);
 
-  public void set(final String region, final Object key, Object value, final long timeoutInSeconds) {
-    set(region, key, value, timeoutInSeconds, TimeUnit.SECONDS);
-  }
-
-  public void set(final String region, final Object key, Object value, final long timeout, final TimeUnit unit) {
-    log.trace("set cache item. region={}, key={}, timeout={}, unit={}",
-              region, key, timeout, unit);
-
-    RMapCache<Object, Object> cache = getCache(region);
-    if (timeout > 0L) {
-      cache.fastPut(key, value, timeout, unit);
-    } else {
+    RClusteredMap<Object, Object> cache = getCache(region);
+    //TODO(jontejj): Removed because of CROSSSLOT issues redisson PRO is working on such a structure for 2017
+    //if (timeout > 0L) {
+    //  cache.fastPut(key, value, timeout, unit);
+    //} else {
       cache.fastPut(key, value);
-    }
+    //}
   }
 
   public void expire(final String region) {
@@ -155,13 +134,13 @@ public class RedisClient {
     redisson.shutdown();
   }
 
-  private final ConcurrentMap<String, RMapCache<Object, Object>> caches = new ConcurrentHashMap<String, RMapCache<Object, Object>>();
+  private final ConcurrentMap<String, RClusteredMap<Object, Object>> caches = new ConcurrentHashMap<String, RClusteredMap<Object, Object>>();
 
-  private RMapCache<Object, Object> getCache(final String region) {
-    RMapCache<Object, Object> cache = caches.get(region);
+  private RClusteredMap<Object, Object> getCache(final String region) {
+    RClusteredMap<Object, Object> cache = caches.get(region);
     if (cache == null) {
-      cache = redisson.getMapCache(region);
-      RMapCache<Object, Object> concurrent = caches.putIfAbsent(region, cache);
+      cache = redisson.getClusteredMap(region);
+      RClusteredMap<Object, Object> concurrent = caches.putIfAbsent(region, cache);
       if (concurrent != null) {
         cache = concurrent;
       }

--- a/hibernate-redis-client/src/main/java/org/hibernate/cache/redis/util/RedisCacheUtil.java
+++ b/hibernate-redis-client/src/main/java/org/hibernate/cache/redis/util/RedisCacheUtil.java
@@ -34,8 +34,6 @@ public final class RedisCacheUtil {
 
   public static final String FILE_URL_PREFIX = "file:";
   public static final String RESOURCE_URL_PREFIX = "classpath:";
-  public static final String EXPIRY_PROPERTY_PREFIX = "redis.expiryInSeconds";
-  public static final int DEFAULT_EXPIRY_IN_SECONDS = 120;
 
   public static final String REDISSON_CONFIG = "redisson-config";
   public static final String DEFAULT_REDISSON_CONFIG_PATH = "classpath:conf/redisson.yaml";
@@ -43,13 +41,7 @@ public final class RedisCacheUtil {
 
   private static final Properties cacheProperties = new Properties();
 
-  private static int defaultExpiryInSeconds = DEFAULT_EXPIRY_IN_SECONDS;
-
   private RedisCacheUtil() { }
-
-  public static int getDefaultExpiryInSeconds() {
-    return defaultExpiryInSeconds;
-  }
 
   /**
    * Load hibernate-redis.properties
@@ -66,8 +58,6 @@ public final class RedisCacheUtil {
       log.debug("Loading cache properties... path={}", cachePropsPath);
       is = getFileInputStream(cachePropsPath);
       cacheProperties.load(is);
-      loadDefaultExpiry();
-
     } catch (Exception e) {
       log.warn("Fail to load cache properties. path={}", cachePropsPath, e);
     } finally {
@@ -101,44 +91,12 @@ public final class RedisCacheUtil {
   }
 
   /**
-   * Load default expiry (seconds)
-   */
-  private static void loadDefaultExpiry() {
-    try {
-      defaultExpiryInSeconds = Integer.parseInt(getProperty(EXPIRY_PROPERTY_PREFIX + ".default", String.valueOf(DEFAULT_EXPIRY_IN_SECONDS)));
-    } catch (Exception ignored) {
-      defaultExpiryInSeconds = DEFAULT_EXPIRY_IN_SECONDS;
-    }
-  }
-
-  /**
    * Get Redisson configuration file path (redisson.yaml)
    *
    * @return Redisson configuration yaml file path
    */
   public static String getRedissonConfigPath() {
     return cacheProperties.getProperty(REDISSON_CONFIG, DEFAULT_REDISSON_CONFIG_PATH);
-  }
-
-
-  /**
-   * get expiry timeout (seconds) by region name.
-   *
-   * @param region region name
-   * @return expiry (seconds)
-   */
-  public static int getExpiryInSeconds(final String region) {
-    try {
-      String key = EXPIRY_PROPERTY_PREFIX + "." + region;
-      String value = getProperty(key, String.valueOf(defaultExpiryInSeconds));
-
-      log.trace("load expiry property. region={}, expiryInSeconds={}", key, value);
-
-      return Integer.parseInt(value);
-    } catch (Exception e) {
-      log.warn("Fail to get expiryInSeconds in region={}", region, e);
-      return defaultExpiryInSeconds;
-    }
   }
 
   /**

--- a/hibernate-redis-client/src/test/java/org/hibernate/cache/redis/config/HibernateRedisConfigTest.java
+++ b/hibernate-redis-client/src/test/java/org/hibernate/cache/redis/config/HibernateRedisConfigTest.java
@@ -60,9 +60,5 @@ public class HibernateRedisConfigTest {
     String redissonConf = props.getProperty("redisson-config");
     assertThat(redissonConf).isNotEmpty();
 
-    // default expiry
-    int defaultExpiry = RedisCacheUtil.getExpiryInSeconds("xx");
-    log.debug("defaultExpiry={}", defaultExpiry);
-    assertThat(defaultExpiry).isEqualTo(RedisCacheUtil.getDefaultExpiryInSeconds());
   }
 }

--- a/hibernate-redis-client/src/test/java/org/hibernate/cache/redis/util/RedisCacheUtilTest.java
+++ b/hibernate-redis-client/src/test/java/org/hibernate/cache/redis/util/RedisCacheUtilTest.java
@@ -22,13 +22,6 @@ public class RedisCacheUtilTest {
 
     RedisCacheUtil.loadCacheProperties(props);
 
-    int expire = RedisCacheUtil.getExpiryInSeconds("xx");
-    log.debug("no defined region's expiry in seconds={}", expire);
-    assertThat(expire).isEqualTo(RedisCacheUtil.getDefaultExpiryInSeconds());
-
-    assertThat(RedisCacheUtil.getExpiryInSeconds("default")).isEqualTo(360);
-    assertThat(RedisCacheUtil.getExpiryInSeconds("hibernate.common")).isEqualTo(0);
-    assertThat(RedisCacheUtil.getExpiryInSeconds("hibernate.account")).isEqualTo(1200);
   }
 
   @Test
@@ -42,9 +35,6 @@ public class RedisCacheUtilTest {
 
     RedisCacheUtil.loadCacheProperties(props);
 
-    assertThat(RedisCacheUtil.getExpiryInSeconds("default")).isEqualTo(240);
-    assertThat(RedisCacheUtil.getExpiryInSeconds("hibernate.common")).isEqualTo(0);
-    assertThat(RedisCacheUtil.getExpiryInSeconds("hibernate.account")).isEqualTo(2400);
   }
 
   @Test

--- a/hibernate-redis-client/src/test/resources/conf/hibernate-redis.properties
+++ b/hibernate-redis-client/src/test/resources/conf/hibernate-redis.properties
@@ -20,13 +20,3 @@
 # if you want outside file (use file:conf/redisson.yaml)
 #
 redisson-config=classpath:conf/redisson.yaml
-#
-# Cache Expiry settings
-# 'hibernate' is second cache prefix
-# 'common', 'account' is actual region name
-#
-# default = 120 seconds (2 minutes) (see RedisCacheUtil.DEFAULT_EXPIRY_IN_SECONDS)
-#
-redis.expiryInSeconds.default=360
-redis.expiryInSeconds.hibernate.common=0
-redis.expiryInSeconds.hibernate.account=1200

--- a/hibernate-redis-client/src/test/resources/conf/redisson.yaml
+++ b/hibernate-redis-client/src/test/resources/conf/redisson.yaml
@@ -1,29 +1,32 @@
 # redisson configuration for redis servers
 # see : https://github.com/mrniko/redisson/wiki/2.-Configuration
 
-singleServerConfig:
+clusterServersConfig:
   idleConnectionTimeout: 10000
   pingTimeout: 1000
-  connectTimeout: 1000
-  timeout: 1000
-  retryAttempts: 1
-  retryInterval: 1000
+  connectTimeout: 10000
+  timeout: 3000
+  retryAttempts: 3
+  retryInterval: 1500
   reconnectionTimeout: 3000
-  failedAttempts: 1
+  failedAttempts: 3
   password: null
   subscriptionsPerConnection: 5
   clientName: null
-  address:
+  loadBalancer: !<org.redisson.connection.balancer.RoundRobinLoadBalancer> {}
+  slaveSubscriptionConnectionMinimumIdleSize: 1
+  slaveSubscriptionConnectionPoolSize: 50
+  slaveConnectionMinimumIdleSize: 5
+  slaveConnectionPoolSize: 250
+  masterConnectionMinimumIdleSize: 5
+  masterConnectionPoolSize: 250
+  readMode: "SLAVE"
+  nodeAddresses:
   - "//127.0.0.1:6379"
-  subscriptionConnectionMinimumIdleSize: 1
-  subscriptionConnectionPoolSize: 25
-  connectionMinimumIdleSize: 5
-  connectionPoolSize: 100
-  database: 0
-  dnsMonitoring: false
-  dnsMonitoringInterval: 5000
+  - "//127.0.0.1:6381"
+  - "//127.0.0.1:6382"
+  scanInterval: 1000
 threads: 0
-# Codec
+nettyThreads: 0
 codec: !<org.redisson.codec.SnappyCodec> {}
 useLinuxNativeEpoll: false
-eventLoopGroup: null

--- a/hibernate-redis-stresser/pom.xml
+++ b/hibernate-redis-stresser/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.debop</groupId>
         <artifactId>hibernate-redis-parent</artifactId>
-        <version>2.3.3-INTERNAL-SNAPSHOT</version>
+        <version>2.3.4-INTERNAL-SNAPSHOT</version>
     </parent>
 
     <artifactId>hibernate-redis-stresser</artifactId>

--- a/hibernate-redis-stresser/pom.xml
+++ b/hibernate-redis-stresser/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.debop</groupId>
         <artifactId>hibernate-redis-parent</artifactId>
-        <version>2.3.3-SNAPSHOT</version>
+        <version>2.3.3-INTERNAL-SNAPSHOT</version>
     </parent>
 
     <artifactId>hibernate-redis-stresser</artifactId>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.github.debop</groupId>
             <artifactId>hibernate-redis</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/hibernate-redis-stresser/pom.xml
+++ b/hibernate-redis-stresser/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.debop</groupId>
         <artifactId>hibernate-redis-parent</artifactId>
-        <version>2.3.4-INTERNAL-SNAPSHOT</version>
+        <version>2.3.4-INTERNAL</version>
     </parent>
 
     <artifactId>hibernate-redis-stresser</artifactId>

--- a/hibernate-redis-stresser/pom.xml
+++ b/hibernate-redis-stresser/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.debop</groupId>
         <artifactId>hibernate-redis-parent</artifactId>
-        <version>2.3.4-INTERNAL</version>
+        <version>2.3.5-INTERNAL-SNAPSHOT</version>
     </parent>
 
     <artifactId>hibernate-redis-stresser</artifactId>

--- a/hibernate-redis-stresser/src/main/resources/hibernate-redis.properties
+++ b/hibernate-redis-stresser/src/main/resources/hibernate-redis.properties
@@ -1,6 +1,1 @@
 #redisson-config=classpath:/redisson.yaml
-
-# Hibernate 2nd cache default expiry (seconds)
-redis.expiryInSeconds=60
-
-redis.expiryInSeconds.hibernate.Player=60

--- a/hibernate-redis/pom.xml
+++ b/hibernate-redis/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.3-SNAPSHOT</version>
+    <version>2.3.3-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -31,7 +31,7 @@
   <description>Hibernate 2nd cache provider with Redis</description>
 
   <properties>
-    <hibernate.redis.version>2.3.3-SNAPSHOT</hibernate.redis.version>
+    <hibernate.redis.version>2.3.3-INTERNAL-SNAPSHOT</hibernate.redis.version>
   </properties>
 
   <dependencies>
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.redisson</groupId>
       <artifactId>redisson</artifactId>
-      <version>2.5.1</version>
+      <classifier>pro</classifier>
     </dependency>
 
     <dependency>

--- a/hibernate-redis/pom.xml
+++ b/hibernate-redis/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.4-INTERNAL-SNAPSHOT</version>
+    <version>2.3.4-INTERNAL</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -31,7 +31,7 @@
   <description>Hibernate 2nd cache provider with Redis</description>
 
   <properties>
-    <hibernate.redis.version>2.3.4-INTERNAL-SNAPSHOT</hibernate.redis.version>
+    <hibernate.redis.version>2.3.4-INTERNAL</hibernate.redis.version>
   </properties>
 
   <dependencies>

--- a/hibernate-redis/pom.xml
+++ b/hibernate-redis/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.3-INTERNAL-SNAPSHOT</version>
+    <version>2.3.4-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -31,7 +31,7 @@
   <description>Hibernate 2nd cache provider with Redis</description>
 
   <properties>
-    <hibernate.redis.version>2.3.3-INTERNAL-SNAPSHOT</hibernate.redis.version>
+    <hibernate.redis.version>2.3.4-INTERNAL-SNAPSHOT</hibernate.redis.version>
   </properties>
 
   <dependencies>

--- a/hibernate-redis/pom.xml
+++ b/hibernate-redis/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.4-INTERNAL</version>
+    <version>2.3.5-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -31,7 +31,7 @@
   <description>Hibernate 2nd cache provider with Redis</description>
 
   <properties>
-    <hibernate.redis.version>2.3.4-INTERNAL</hibernate.redis.version>
+    <hibernate.redis.version>2.3.5-INTERNAL-SNAPSHOT</hibernate.redis.version>
   </properties>
 
   <dependencies>

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.4-INTERNAL-SNAPSHOT</version>
+    <version>2.3.4-INTERNAL</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.3-SNAPSHOT</version>
+    <version>2.3.3-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.3-INTERNAL-SNAPSHOT</version>
+    <version>2.3.4-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.4-INTERNAL</version>
+    <version>2.3.5-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate4/src/main/java/org/hibernate/cache/redis/hibernate4/regions/RedisDataRegion.java
+++ b/hibernate4/src/main/java/org/hibernate/cache/redis/hibernate4/regions/RedisDataRegion.java
@@ -57,8 +57,6 @@ public abstract class RedisDataRegion implements Region {
 
   @Getter
   private final int cacheLockTimeout; // milliseconds
-  @Getter
-  private final int expiryInSeconds;  // seconds
 
   protected RedisDataRegion(RedisAccessStrategyFactory accessStrategyFactory,
                             RedisClient redis, ConfigurableRedisRegionFactory configurableRedisRegionFactory,
@@ -70,8 +68,7 @@ public abstract class RedisDataRegion implements Region {
     this.cacheTimestamper = configurableRedisRegionFactory.createCacheTimestamper(redis, regionName);
 
     this.cacheLockTimeout = 0;
-    this.expiryInSeconds = RedisCacheUtil.getExpiryInSeconds(name);
-    log.debug("redis region={}, expiryInSeconds={}", regionName, expiryInSeconds);
+    log.debug("redis region={}", regionName);
   }
 
   /**

--- a/hibernate4/src/main/java/org/hibernate/cache/redis/hibernate4/regions/RedisGeneralDataRegion.java
+++ b/hibernate4/src/main/java/org/hibernate/cache/redis/hibernate4/regions/RedisGeneralDataRegion.java
@@ -54,7 +54,7 @@ public abstract class RedisGeneralDataRegion extends RedisDataRegion implements 
   @Override
   public void put(Object key, Object value) {
     try {
-      redis.set(getName(), key, value, getExpiryInSeconds());
+      redis.set(getName(), key, value);
     } catch (Exception e) {
       log.warn("Fail to put cache item... key=" + key, e);
     }

--- a/hibernate4/src/main/java/org/hibernate/cache/redis/hibernate4/regions/RedisTransactionalDataRegion.java
+++ b/hibernate4/src/main/java/org/hibernate/cache/redis/hibernate4/regions/RedisTransactionalDataRegion.java
@@ -83,7 +83,7 @@ public class RedisTransactionalDataRegion extends RedisDataRegion implements Tra
 
   public void put(Object key, Object value) {
     try {
-      redis.set(getName(), key, value, getExpiryInSeconds());
+      redis.set(getName(), key, value);
     } catch (Exception e) {
       log.warn("Fail to put cache item... key=" + key, e);
     }

--- a/hibernate4/src/test/resources/conf/hibernate-redis.properties
+++ b/hibernate4/src/test/resources/conf/hibernate-redis.properties
@@ -20,13 +20,3 @@
 # if you want outside file (use file:conf/redisson.yaml)
 #
 redisson-config=classpath:conf/redisson.yaml
-#
-# Cache Expiry settings
-# 'hibernate' is second cache prefix
-# 'common', 'account' is actual region name
-#
-# default = 120 seconds (2 minutes) (see RedisCacheUtil.DEFAULT_EXPIRY_IN_SECONDS)
-#
-redis.expiryInSeconds.default=360
-redis.expiryInSeconds.hibernate.common=0
-redis.expiryInSeconds.hibernate.account=1200

--- a/hibernate4/src/test/resources/conf/redisson.yaml
+++ b/hibernate4/src/test/resources/conf/redisson.yaml
@@ -1,28 +1,32 @@
 # redisson configuration for redis servers
 # see : https://github.com/mrniko/redisson/wiki/2.-Configuration
 
-singleServerConfig:
+clusterServersConfig:
   idleConnectionTimeout: 10000
   pingTimeout: 1000
-  connectTimeout: 1000
-  timeout: 1000
+  connectTimeout: 10000
+  timeout: 3000
   retryAttempts: 3
-  retryInterval: 1000
+  retryInterval: 1500
   reconnectionTimeout: 3000
   failedAttempts: 3
   password: null
   subscriptionsPerConnection: 5
   clientName: null
-  address:
+  loadBalancer: !<org.redisson.connection.balancer.RoundRobinLoadBalancer> {}
+  slaveSubscriptionConnectionMinimumIdleSize: 1
+  slaveSubscriptionConnectionPoolSize: 50
+  slaveConnectionMinimumIdleSize: 5
+  slaveConnectionPoolSize: 250
+  masterConnectionMinimumIdleSize: 5
+  masterConnectionPoolSize: 250
+  readMode: "SLAVE"
+  nodeAddresses:
   - "//127.0.0.1:6379"
-  subscriptionConnectionMinimumIdleSize: 1
-  subscriptionConnectionPoolSize: 25
-  connectionMinimumIdleSize: 5
-  connectionPoolSize: 100
-  database: 0
-  dnsMonitoring: false
-  dnsMonitoringInterval: 5000
+  - "//127.0.0.1:6381"
+  - "//127.0.0.1:6382"
+  scanInterval: 1000
 threads: 0
+nettyThreads: 0
 codec: !<org.redisson.codec.SnappyCodec> {}
 useLinuxNativeEpoll: false
-eventLoopGroup: null

--- a/hibernate5/pom.xml
+++ b/hibernate5/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.4-INTERNAL-SNAPSHOT</version>
+    <version>2.3.4-INTERNAL</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate5/pom.xml
+++ b/hibernate5/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.3-SNAPSHOT</version>
+    <version>2.3.3-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate5/pom.xml
+++ b/hibernate5/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.3-INTERNAL-SNAPSHOT</version>
+    <version>2.3.4-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate5/pom.xml
+++ b/hibernate5/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.4-INTERNAL</version>
+    <version>2.3.5-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisDataRegion.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisDataRegion.java
@@ -54,9 +54,6 @@ public abstract class RedisDataRegion implements Region {
 
   private final CacheTimestamper cacheTimestamper;
 
-  @Getter
-  private final int expiryInSeconds;  // seconds
-
   public RedisDataRegion(RedisAccessStrategyFactory accessStrategyFactory,
                          RedisClient redis, ConfigurableRedisRegionFactory configurableRedisRegionFactory,
                          String regionName,
@@ -66,8 +63,7 @@ public abstract class RedisDataRegion implements Region {
     this.regionName = regionName;
     this.cacheTimestamper = configurableRedisRegionFactory.createCacheTimestamper(redis, regionName);
 
-    this.expiryInSeconds = RedisCacheUtil.getExpiryInSeconds(this.regionName);
-    log.debug("redis region={}, expiryInSeconds={}", regionName, expiryInSeconds);
+    log.debug("redis region={}", regionName);
   }
 
   /**

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisGeneralDataRegion.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisGeneralDataRegion.java
@@ -54,7 +54,7 @@ public class RedisGeneralDataRegion extends RedisDataRegion implements GeneralDa
   @Override
   public void put(SessionImplementor session, Object key, Object value) throws CacheException {
     try {
-      redis.set(getName(), key, value, getExpiryInSeconds());
+      redis.set(getName(), key, value);
     } catch (Exception ignored) {
       log.warn("Fail to put. key=" + key, ignored);
     }

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisTransactionalDataRegion.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisTransactionalDataRegion.java
@@ -79,7 +79,7 @@ public class RedisTransactionalDataRegion extends RedisDataRegion implements Tra
 
   public void put(Object key, Object value) {
     try {
-      redis.set(getName(), key, value, getExpiryInSeconds());
+      redis.set(getName(), key, value);
     } catch (Exception ignored) {
       log.warn("Fail to put cache item... key=" + key, ignored);
     }

--- a/hibernate5/src/test/resources/conf/hibernate-redis.properties
+++ b/hibernate5/src/test/resources/conf/hibernate-redis.properties
@@ -20,13 +20,3 @@
 # if you want outside file (use file:conf/redisson.yaml)
 #
 redisson-config=classpath:conf/redisson.yaml
-#
-# Cache Expiry settings
-# 'hibernate' is second cache prefix
-# 'common', 'account' is actual region name
-#
-# default = 120 seconds (2 minutes) (see RedisCacheUtil.DEFAULT_EXPIRY_IN_SECONDS)
-#
-redis.expiryInSeconds.default=360
-redis.expiryInSeconds.hibernate.common=0
-redis.expiryInSeconds.hibernate.account=1200

--- a/hibernate5/src/test/resources/conf/redisson.yaml
+++ b/hibernate5/src/test/resources/conf/redisson.yaml
@@ -1,29 +1,32 @@
 # redisson configuration for redis servers
 # see : https://github.com/mrniko/redisson/wiki/2.-Configuration
 
-singleServerConfig:
+clusterServersConfig:
   idleConnectionTimeout: 10000
   pingTimeout: 1000
-  connectTimeout: 1000
-  timeout: 1000
+  connectTimeout: 10000
+  timeout: 3000
   retryAttempts: 3
-  retryInterval: 1000
+  retryInterval: 1500
   reconnectionTimeout: 3000
   failedAttempts: 3
   password: null
   subscriptionsPerConnection: 5
   clientName: null
-  address:
+  loadBalancer: !<org.redisson.connection.balancer.RoundRobinLoadBalancer> {}
+  slaveSubscriptionConnectionMinimumIdleSize: 1
+  slaveSubscriptionConnectionPoolSize: 50
+  slaveConnectionMinimumIdleSize: 5
+  slaveConnectionPoolSize: 250
+  masterConnectionMinimumIdleSize: 5
+  masterConnectionPoolSize: 250
+  readMode: "SLAVE"
+  nodeAddresses:
   - "//127.0.0.1:6379"
-  subscriptionConnectionMinimumIdleSize: 1
-  subscriptionConnectionPoolSize: 25
-  connectionMinimumIdleSize: 5
-  connectionPoolSize: 100
-  database: 0
-  dnsMonitoring: false
-  dnsMonitoringInterval: 5000
+  - "//127.0.0.1:6381"
+  - "//127.0.0.1:6382"
+  scanInterval: 1000
 threads: 0
-# Codec
+nettyThreads: 0
 codec: !<org.redisson.codec.SnappyCodec> {}
 useLinuxNativeEpoll: false
-eventLoopGroup: null

--- a/hibernate52/pom.xml
+++ b/hibernate52/pom.xml
@@ -19,7 +19,11 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
+<<<<<<< 980006da4433b1e30f231e9b2e1f4d0757eb07d0
     <version>2.3.3-INTERNAL-SNAPSHOT</version>
+=======
+    <version>2.3.4-INTERNAL-SNAPSHOT</version>
+>>>>>>> Changed from redisson to redisson PRO because of CROSSSLOT issues when deleting cache entries
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate52/pom.xml
+++ b/hibernate52/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.4-INTERNAL-SNAPSHOT</version>
+    <version>2.3.4-INTERNAL</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate52/pom.xml
+++ b/hibernate52/pom.xml
@@ -19,11 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-<<<<<<< 980006da4433b1e30f231e9b2e1f4d0757eb07d0
-    <version>2.3.3-INTERNAL-SNAPSHOT</version>
-=======
     <version>2.3.4-INTERNAL-SNAPSHOT</version>
->>>>>>> Changed from redisson to redisson PRO because of CROSSSLOT issues when deleting cache entries
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate52/pom.xml
+++ b/hibernate52/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.3-SNAPSHOT</version>
+    <version>2.3.3-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate52/pom.xml
+++ b/hibernate52/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hibernate-redis-parent</artifactId>
     <groupId>com.github.debop</groupId>
-    <version>2.3.4-INTERNAL</version>
+    <version>2.3.5-INTERNAL-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisDataRegion.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisDataRegion.java
@@ -54,9 +54,6 @@ public abstract class RedisDataRegion implements Region {
 
   private final CacheTimestamper cacheTimestamper;
 
-  @Getter
-  private final int expiryInSeconds;  // seconds
-
   public RedisDataRegion(RedisAccessStrategyFactory accessStrategyFactory,
                          RedisClient redis, ConfigurableRedisRegionFactory configurableRedisRegionFactory,
                          String regionName,
@@ -66,8 +63,7 @@ public abstract class RedisDataRegion implements Region {
     this.regionName = regionName;
     this.cacheTimestamper = configurableRedisRegionFactory.createCacheTimestamper(redis, regionName);
 
-    this.expiryInSeconds = RedisCacheUtil.getExpiryInSeconds(this.regionName);
-    log.debug("redis region={}, expiryInSeconds={}", regionName, expiryInSeconds);
+    log.debug("redis region={}", regionName);
   }
 
   /**

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisGeneralDataRegion.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisGeneralDataRegion.java
@@ -54,7 +54,7 @@ public class RedisGeneralDataRegion extends RedisDataRegion implements GeneralDa
   @Override
   public void put(SharedSessionContractImplementor session, Object key, Object value) throws CacheException {
     try {
-      redis.set(getName(), key, value, getExpiryInSeconds());
+      redis.set(getName(), key, value);
     } catch (Exception ignored) {
       log.warn("Fail to put. key=" + key, ignored);
     }

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisTransactionalDataRegion.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisTransactionalDataRegion.java
@@ -79,7 +79,7 @@ public class RedisTransactionalDataRegion extends RedisDataRegion implements Tra
 
   public void put(Object key, Object value) {
     try {
-      redis.set(getName(), key, value, getExpiryInSeconds());
+      redis.set(getName(), key, value);
     } catch (Exception ignored) {
       log.warn("Fail to put cache item... key=" + key, ignored);
     }

--- a/hibernate52/src/test/resources/conf/redisson.yaml
+++ b/hibernate52/src/test/resources/conf/redisson.yaml
@@ -1,29 +1,32 @@
 # redisson configuration for redis servers
 # see : https://github.com/mrniko/redisson/wiki/2.-Configuration
 
-singleServerConfig:
+clusterServersConfig:
   idleConnectionTimeout: 10000
   pingTimeout: 1000
-  connectTimeout: 1000
-  timeout: 1000
+  connectTimeout: 10000
+  timeout: 3000
   retryAttempts: 3
-  retryInterval: 1000
+  retryInterval: 1500
   reconnectionTimeout: 3000
   failedAttempts: 3
   password: null
   subscriptionsPerConnection: 5
   clientName: null
-  address:
+  loadBalancer: !<org.redisson.connection.balancer.RoundRobinLoadBalancer> {}
+  slaveSubscriptionConnectionMinimumIdleSize: 1
+  slaveSubscriptionConnectionPoolSize: 50
+  slaveConnectionMinimumIdleSize: 5
+  slaveConnectionPoolSize: 250
+  masterConnectionMinimumIdleSize: 5
+  masterConnectionPoolSize: 250
+  readMode: "SLAVE"
+  nodeAddresses:
   - "//127.0.0.1:6379"
-  subscriptionConnectionMinimumIdleSize: 1
-  subscriptionConnectionPoolSize: 25
-  connectionMinimumIdleSize: 5
-  connectionPoolSize: 100
-  database: 0
-  dnsMonitoring: false
-  dnsMonitoringInterval: 5000
+  - "//127.0.0.1:6381"
+  - "//127.0.0.1:6382"
+  scanInterval: 1000
 threads: 0
-# Codec
+nettyThreads: 0
 codec: !<org.redisson.codec.SnappyCodec> {}
 useLinuxNativeEpoll: false
-eventLoopGroup: null

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.github.debop</groupId>
   <artifactId>hibernate-redis-parent</artifactId>
-  <version>2.3.3-SNAPSHOT</version>
+  <version>2.3.3-INTERNAL-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>hibernate-redis</name>
@@ -46,21 +46,23 @@
   </modules>
 
   <scm>
-    <connection>scm:git:ssh://git@github.com/debop/hibernate-redis.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/debop/hibernate-redis.git</developerConnection>
-    <url>https://github.com/debop/hibernate-redis</url>
+    <url>https://github.com/jontejj/hibernate-redis</url>
+    <connection>scm:git:git://github.com/jontejj/hibernate-redis.git</connection>
+    <developerConnection>scm:git:git@github.com:jontejj/hibernate-redis.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
     <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>deployment</id>
+      <name>Internal Releases</name>
+      <url>http://10.98.32.25:8081/nexus/content/repositories/releases/</url>
     </repository>
+    <snapshotRepository>
+      <id>deployment</id>
+      <name>Internal Releases</name>
+      <url>http://10.98.32.25:8081/nexus/content/repositories/snapshots/</url>
+    </snapshotRepository>
   </distributionManagement>
 
   <issueManagement>
@@ -122,7 +124,8 @@
       <dependency>
         <groupId>org.redisson</groupId>
         <artifactId>redisson</artifactId>
-        <version>2.5.1</version>
+        <version>2.7.0</version>
+        <classifier>pro</classifier>
       </dependency>
 
       <dependency>
@@ -244,6 +247,12 @@
   </dependencyManagement>
 
   <dependencies>
+
+    <dependency>
+      <groupId>org.redisson</groupId>
+      <artifactId>redisson</artifactId>
+      <classifier>pro</classifier>
+    </dependency>
 
     <!-- Logging -->
     <dependency>
@@ -394,8 +403,33 @@
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5</version>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+        <configuration>
+          <systemProperties>
+            <property>
+              <name>redisson.pro.key</name>
+              <value>${redisson.pro.key}</value>
+            </property>
+          </systemProperties>
+        </configuration>
+      </plugin>
     </plugins>
+
   </build>
+
+  <repositories>
+    <repository>
+      <id>redisson-repo</id>
+      <url>http://redisson.pro/repo/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
   <profiles>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.github.debop</groupId>
   <artifactId>hibernate-redis-parent</artifactId>
-  <version>2.3.4-INTERNAL-SNAPSHOT</version>
+  <version>2.3.4-INTERNAL</version>
   <packaging>pom</packaging>
 
   <name>hibernate-redis</name>
@@ -49,7 +49,7 @@
     <url>https://github.com/jontejj/hibernate-redis</url>
     <connection>scm:git:git://github.com/jontejj/hibernate-redis.git</connection>
     <developerConnection>scm:git:git@github.com:jontejj/hibernate-redis.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>hibernate-redis-parent-2.3.4-INTERNAL</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.github.debop</groupId>
   <artifactId>hibernate-redis-parent</artifactId>
-  <version>2.3.4-INTERNAL</version>
+  <version>2.3.5-INTERNAL-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>hibernate-redis</name>
@@ -49,7 +49,7 @@
     <url>https://github.com/jontejj/hibernate-redis</url>
     <connection>scm:git:git://github.com/jontejj/hibernate-redis.git</connection>
     <developerConnection>scm:git:git@github.com:jontejj/hibernate-redis.git</developerConnection>
-    <tag>hibernate-redis-parent-2.3.4-INTERNAL</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.github.debop</groupId>
   <artifactId>hibernate-redis-parent</artifactId>
-  <version>2.3.3-INTERNAL-SNAPSHOT</version>
+  <version>2.3.4-INTERNAL-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>hibernate-redis</name>


### PR DESCRIPTION
I understand that this won't be merged because it's using a proprietary redisson PRO version. But maybe you can look into why RMapCache is having problems when configured against a cluster? Or is there some config we are missing?