### PR TITLE
Hibernate 5.0.11 problem

### DIFF
--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/NonStrictReadWriteRedisCollectionRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/NonStrictReadWriteRedisCollectionRegionAccessStrategy.java
@@ -49,12 +49,12 @@ public class NonStrictReadWriteRedisCollectionRegionAccessStrategy
                                  CollectionPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.staticCreateCollectionKey(id, persister, factory, tenantIdentifier);
+    return DefaultCacheKeysFactory.INSTANCE.createCollectionKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.staticGetCollectionId(cacheKey);
+    return DefaultCacheKeysFactory.INSTANCE.getCollectionId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/NonStrictReadWriteRedisEntityRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/NonStrictReadWriteRedisEntityRegionAccessStrategy.java
@@ -47,12 +47,12 @@ public class NonStrictReadWriteRedisEntityRegionAccessStrategy
                                  EntityPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.staticCreateEntityKey(id, persister, factory, tenantIdentifier);
+    return DefaultCacheKeysFactory.INSTANCE.createEntityKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.staticGetEntityId(cacheKey);
+    return DefaultCacheKeysFactory.INSTANCE.getEntityId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/NonStrictReadWriteRedisNaturalIdRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/NonStrictReadWriteRedisNaturalIdRegionAccessStrategy.java
@@ -46,12 +46,12 @@ public class NonStrictReadWriteRedisNaturalIdRegionAccessStrategy
 
   @Override
   public Object generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SessionImplementor session) {
-    return DefaultCacheKeysFactory.staticCreateNaturalIdKey(naturalIdValues, persister, session);
+    return DefaultCacheKeysFactory.INSTANCE.createNaturalIdKey(naturalIdValues, persister, session);
   }
 
   @Override
   public Object[] getNaturalIdValues(Object cacheKey) {
-    return DefaultCacheKeysFactory.staticGetNaturalIdValues(cacheKey);
+    return DefaultCacheKeysFactory.INSTANCE.getNaturalIdValues(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadOnlyRedisCollectionRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadOnlyRedisCollectionRegionAccessStrategy.java
@@ -48,12 +48,12 @@ public class ReadOnlyRedisCollectionRegionAccessStrategy
                                  CollectionPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.staticCreateCollectionKey(id, persister, factory, tenantIdentifier);
+    return DefaultCacheKeysFactory.INSTANCE.createCollectionKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.staticGetCollectionId(cacheKey);
+    return DefaultCacheKeysFactory.INSTANCE.getCollectionId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadOnlyRedisEntityRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadOnlyRedisEntityRegionAccessStrategy.java
@@ -48,7 +48,7 @@ public class ReadOnlyRedisEntityRegionAccessStrategy
                                  EntityPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.staticCreateEntityKey(id, persister, factory, tenantIdentifier);
+    return DefaultCacheKeysFactory.INSTANCE.createEntityKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadOnlyRedisNaturalIdRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadOnlyRedisNaturalIdRegionAccessStrategy.java
@@ -46,12 +46,12 @@ public class ReadOnlyRedisNaturalIdRegionAccessStrategy
   public Object generateCacheKey(Object[] naturalIdValues,
                                  EntityPersister persister,
                                  SessionImplementor session) {
-    return DefaultCacheKeysFactory.staticCreateNaturalIdKey(naturalIdValues, persister, session);
+    return DefaultCacheKeysFactory.INSTANCE.createNaturalIdKey(naturalIdValues, persister, session);
   }
 
   @Override
   public Object[] getNaturalIdValues(Object cacheKey) {
-    return DefaultCacheKeysFactory.staticGetNaturalIdValues(cacheKey);
+    return DefaultCacheKeysFactory.INSTANCE.getNaturalIdValues(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadWriteRedisCollectionRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadWriteRedisCollectionRegionAccessStrategy.java
@@ -46,12 +46,12 @@ public class ReadWriteRedisCollectionRegionAccessStrategy
                                  CollectionPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.staticCreateCollectionKey(id, persister, factory, tenantIdentifier);
+    return DefaultCacheKeysFactory.INSTANCE.createCollectionKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.staticGetCollectionId(cacheKey);
+    return DefaultCacheKeysFactory.INSTANCE.getCollectionId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadWriteRedisEntityRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadWriteRedisEntityRegionAccessStrategy.java
@@ -51,12 +51,12 @@ public class ReadWriteRedisEntityRegionAccessStrategy
                                  EntityPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.staticCreateEntityKey(id, persister, factory, tenantIdentifier);
+    return DefaultCacheKeysFactory.INSTANCE.createEntityKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.staticGetEntityId(cacheKey);
+    return DefaultCacheKeysFactory.INSTANCE.getEntityId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadWriteRedisNaturalIdRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadWriteRedisNaturalIdRegionAccessStrategy.java
@@ -49,12 +49,12 @@ public class ReadWriteRedisNaturalIdRegionAccessStrategy
   public Object generateCacheKey(Object[] naturalIdValues,
                                  EntityPersister persister,
                                  SessionImplementor session) {
-    return DefaultCacheKeysFactory.staticCreateNaturalIdKey(naturalIdValues, persister, session);
+    return DefaultCacheKeysFactory.INSTANCE.createNaturalIdKey(naturalIdValues, persister, session);
   }
 
   @Override
   public Object[] getNaturalIdValues(Object cacheKey) {
-    return DefaultCacheKeysFactory.staticGetNaturalIdValues(cacheKey);
+    return DefaultCacheKeysFactory.INSTANCE.getNaturalIdValues(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/TransactionalRedisCollectionRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/TransactionalRedisCollectionRegionAccessStrategy.java
@@ -54,12 +54,12 @@ public class TransactionalRedisCollectionRegionAccessStrategy
                                  CollectionPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.staticCreateCollectionKey(id, persister, factory, tenantIdentifier);
+    return DefaultCacheKeysFactory.INSTANCE.createCollectionKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.staticGetCollectionId(cacheKey);
+    return DefaultCacheKeysFactory.INSTANCE.getCollectionId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/TransactionalRedisEntityRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/TransactionalRedisEntityRegionAccessStrategy.java
@@ -54,12 +54,12 @@ public class TransactionalRedisEntityRegionAccessStrategy
                                  EntityPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.staticCreateEntityKey(id, persister, factory, tenantIdentifier);
+    return DefaultCacheKeysFactory.INSTANCE.createEntityKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.staticGetEntityId(cacheKey);
+    return DefaultCacheKeysFactory.INSTANCE.getEntityId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/TransactionalRedisNaturalIdRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/TransactionalRedisNaturalIdRegionAccessStrategy.java
@@ -66,12 +66,12 @@ public class TransactionalRedisNaturalIdRegionAccessStrategy
   public Object generateCacheKey(Object[] naturalIdValues,
                                  EntityPersister persister,
                                  SessionImplementor session) {
-    return DefaultCacheKeysFactory.staticCreateNaturalIdKey(naturalIdValues, persister, session);
+    return DefaultCacheKeysFactory.INSTANCE.createNaturalIdKey(naturalIdValues, persister, session);
   }
 
   @Override
   public Object[] getNaturalIdValues(Object cacheKey) {
-    return DefaultCacheKeysFactory.staticGetNaturalIdValues(cacheKey);
+    return DefaultCacheKeysFactory.INSTANCE.getNaturalIdValues(cacheKey);
   }
 
   @Override


### PR DESCRIPTION
Existing code didn't work with hibernate 5.0.11 but worked for 5.0.12. Using INSTANCE in DefaultCacheKeysFactory class instead of static methods makes it possible to work with all hibernate 5.0.x versions. Yes, the reason is version 5.0.11 which is used in some Spring Boot versions by default, DefaultCacheKeysFactory does not have static methods which is used in the codes here.