### PR TITLE
allow load default expiry setting from spring application.properties

### DIFF
--- a/hibernate-redis-client/src/main/java/org/hibernate/cache/redis/util/RedisCacheUtil.java
+++ b/hibernate-redis-client/src/main/java/org/hibernate/cache/redis/util/RedisCacheUtil.java
@@ -75,11 +75,11 @@ public final class RedisCacheUtil {
         log.debug("Loading cache properties... path={}", cachePropsPath);
         is = getFileInputStream(cachePropsPath);
         cacheProperties.load(is);
-        loadDefaultExpiry();
 
       } catch (Exception e) {
         log.warn("Fail to load cache properties. path={}", cachePropsPath, e);
       } finally {
+        loadDefaultExpiry();
         if (is != null) {
           try {
             is.close();

--- a/hibernate-redis-client/src/test/java/org/hibernate/cache/redis/util/RedisCacheUtilTest.java
+++ b/hibernate-redis-client/src/test/java/org/hibernate/cache/redis/util/RedisCacheUtilTest.java
@@ -64,6 +64,27 @@ public class RedisCacheUtilTest {
   }
 
   @Test
+  public void testGetExpiryInSecondsWithPassedPropertiesWithoutProviderConfigurationFileResourcePath() {
+
+    Properties props = new Properties();
+    //the following line is used to simulate there is no configuration on props and there is no default file on "conf/hibernate-redis.properties".
+    //after that we will get is = null on RedisCacheUtil.
+    props.setProperty("hibernate.cache.provider_configuration_file_resource_path", "-");
+    props.setProperty("redis.expiryInSeconds.default", "240");
+    props.setProperty("redis.expiryInSeconds.hibernate.common", "0");
+    props.setProperty("redis.expiryInSeconds.hibernate.account", "2400");
+
+    RedisCacheUtil.loadCacheProperties(props);
+
+    //as real use case, don't call get default expiry
+    //assertThat(RedisCacheUtil.getExpiryInSeconds("default")).isEqualTo(240);
+    assertThat(RedisCacheUtil.getExpiryInSeconds("hibernate.common")).isEqualTo(0);
+    assertThat(RedisCacheUtil.getExpiryInSeconds("hibernate.account")).isEqualTo(2400);
+    //try to load the setting from default
+    assertThat(RedisCacheUtil.getExpiryInSeconds("hibernate.not_defined")).isEqualTo(240);
+  }
+
+  @Test
   public void testGetRedissonConfig() {
 
     Properties props = new Properties();


### PR DESCRIPTION
If we follow the [Readme Doc](https://github.com/debop/hibernate-redis#hibernate-configuration-via-spring-application-property-files) to put the configuration on spring application properties. 

Since we didn't put the value for `hibernate.cache.provider_configuration_file_resource_path`, `RedisCacheUtil` will try to find the default file from `conf/hibernate-redis.properties`. But the file is not exist on the project. 

So It will throw `NullPointerException` before it calls the `loadDefaultExpiry()`. It will have no chance to load the default expiry value.
Once there is a region are trying to use the default value it will always use the hardcoded one `120` instead of the value on properties.

Please check my test cases.