### PR TITLE
Issue-126. custom CacheKeysFactory

### DIFF
--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisCollectionRegion.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisCollectionRegion.java
@@ -22,6 +22,7 @@ import org.hibernate.cache.redis.client.RedisClient;
 import org.hibernate.cache.redis.hibernate5.ConfigurableRedisRegionFactory;
 import org.hibernate.cache.redis.hibernate5.strategy.RedisAccessStrategyFactory;
 import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
@@ -42,8 +43,8 @@ public class RedisCollectionRegion extends RedisTransactionalDataRegion implemen
                                String regionName,
                                SessionFactoryOptions options,
                                CacheDataDescription metadata,
-                               Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, options, metadata, props);
+                               Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, options, metadata, props, cacheKeysFactory);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisDataRegion.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisDataRegion.java
@@ -24,6 +24,7 @@ import org.hibernate.cache.redis.hibernate5.ConfigurableRedisRegionFactory;
 import org.hibernate.cache.redis.hibernate5.strategy.RedisAccessStrategyFactory;
 import org.hibernate.cache.redis.util.CacheTimestamper;
 import org.hibernate.cache.redis.util.RedisCacheUtil;
+import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.Region;
 
 import java.util.Map;
@@ -57,16 +58,19 @@ public abstract class RedisDataRegion implements Region {
   @Getter
   private final int expiryInSeconds;  // seconds
 
+  @Getter
+  private final CacheKeysFactory keysFactory;
+
   public RedisDataRegion(RedisAccessStrategyFactory accessStrategyFactory,
-                         RedisClient redis, ConfigurableRedisRegionFactory configurableRedisRegionFactory,
-                         String regionName,
-                         Properties props) {
+      RedisClient redis, ConfigurableRedisRegionFactory configurableRedisRegionFactory,
+      String regionName,
+      Properties props, CacheKeysFactory cacheKeysFactory) {
     this.accessStrategyFactory = accessStrategyFactory;
     this.redis = redis;
     this.regionName = regionName;
     this.cacheTimestamper = configurableRedisRegionFactory.createCacheTimestamper(redis, regionName);
-
     this.expiryInSeconds = RedisCacheUtil.getExpiryInSeconds(this.regionName);
+    this.keysFactory = cacheKeysFactory;
     log.debug("redis region={}, expiryInSeconds={}", regionName, expiryInSeconds);
   }
 

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisEntityRegion.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisEntityRegion.java
@@ -23,6 +23,7 @@ import org.hibernate.cache.redis.client.RedisClient;
 import org.hibernate.cache.redis.hibernate5.ConfigurableRedisRegionFactory;
 import org.hibernate.cache.redis.hibernate5.strategy.RedisAccessStrategyFactory;
 import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
@@ -43,8 +44,8 @@ public class RedisEntityRegion extends RedisTransactionalDataRegion implements E
                            String regionName,
                            SessionFactoryOptions options,
                            CacheDataDescription metadata,
-                           Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, options, metadata, props);
+                           Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, options, metadata, props, cacheKeysFactory);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisGeneralDataRegion.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisGeneralDataRegion.java
@@ -21,6 +21,7 @@ import org.hibernate.cache.CacheException;
 import org.hibernate.cache.redis.client.RedisClient;
 import org.hibernate.cache.redis.hibernate5.ConfigurableRedisRegionFactory;
 import org.hibernate.cache.redis.hibernate5.strategy.RedisAccessStrategyFactory;
+import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.GeneralDataRegion;
 import org.hibernate.engine.spi.SessionImplementor;
 
@@ -38,8 +39,9 @@ public class RedisGeneralDataRegion extends RedisDataRegion implements GeneralDa
   public RedisGeneralDataRegion(RedisAccessStrategyFactory accessStrategyFactory,
                                 RedisClient redis, ConfigurableRedisRegionFactory configurableRedisRegionFactory,
                                 String regionName,
-                                Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props);
+                                Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props,
+        cacheKeysFactory);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisNaturalIdRegion.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisNaturalIdRegion.java
@@ -23,6 +23,7 @@ import org.hibernate.cache.redis.client.RedisClient;
 import org.hibernate.cache.redis.hibernate5.ConfigurableRedisRegionFactory;
 import org.hibernate.cache.redis.hibernate5.strategy.RedisAccessStrategyFactory;
 import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
@@ -43,8 +44,8 @@ public class RedisNaturalIdRegion extends RedisTransactionalDataRegion implement
                               String regionName,
                               SessionFactoryOptions options,
                               CacheDataDescription metadata,
-                              Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, options, metadata, props);
+                              Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, options, metadata, props, cacheKeysFactory);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisQueryResultsRegion.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisQueryResultsRegion.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.cache.redis.client.RedisClient;
 import org.hibernate.cache.redis.hibernate5.ConfigurableRedisRegionFactory;
 import org.hibernate.cache.redis.hibernate5.strategy.RedisAccessStrategyFactory;
+import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.QueryResultsRegion;
 
 import java.util.Properties;
@@ -36,7 +37,7 @@ public class RedisQueryResultsRegion extends RedisGeneralDataRegion implements Q
   public RedisQueryResultsRegion(RedisAccessStrategyFactory accessStrategyFactory,
                                  RedisClient redis, ConfigurableRedisRegionFactory configurableRedisRegionFactory,
                                  String regionName,
-                                 Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props);
+                                 Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props, cacheKeysFactory);
   }
 }

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisTimestampsRegion.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisTimestampsRegion.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.cache.redis.client.RedisClient;
 import org.hibernate.cache.redis.hibernate5.ConfigurableRedisRegionFactory;
 import org.hibernate.cache.redis.hibernate5.strategy.RedisAccessStrategyFactory;
+import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.TimestampsRegion;
 
 import java.util.Properties;
@@ -36,7 +37,7 @@ public class RedisTimestampsRegion extends RedisGeneralDataRegion implements Tim
   public RedisTimestampsRegion(RedisAccessStrategyFactory accessStrategyFactory,
                                RedisClient redis, ConfigurableRedisRegionFactory configurableRedisRegionFactory,
                                String regionName,
-                               Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props);
+                               Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props, cacheKeysFactory);
   }
 }

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisTransactionalDataRegion.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/regions/RedisTransactionalDataRegion.java
@@ -24,6 +24,7 @@ import org.hibernate.cache.redis.client.RedisClient;
 import org.hibernate.cache.redis.hibernate5.ConfigurableRedisRegionFactory;
 import org.hibernate.cache.redis.hibernate5.strategy.RedisAccessStrategyFactory;
 import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.TransactionalDataRegion;
 
 import java.util.Properties;
@@ -51,8 +52,9 @@ public class RedisTransactionalDataRegion extends RedisDataRegion implements Tra
                                       String regionName,
                                       SessionFactoryOptions options,
                                       CacheDataDescription metadata,
-                                      Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props);
+                                      Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props,
+        cacheKeysFactory);
 
     this.options = options;
     this.metadata = metadata;

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/NonStrictReadWriteRedisCollectionRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/NonStrictReadWriteRedisCollectionRegionAccessStrategy.java
@@ -49,12 +49,12 @@ public class NonStrictReadWriteRedisCollectionRegionAccessStrategy
                                  CollectionPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createCollectionKey(id, persister, factory, tenantIdentifier);
+    return region.getKeysFactory().createCollectionKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getCollectionId(cacheKey);
+    return region.getKeysFactory().getCollectionId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/NonStrictReadWriteRedisEntityRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/NonStrictReadWriteRedisEntityRegionAccessStrategy.java
@@ -47,12 +47,12 @@ public class NonStrictReadWriteRedisEntityRegionAccessStrategy
                                  EntityPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createEntityKey(id, persister, factory, tenantIdentifier);
+    return region.getKeysFactory().createEntityKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getEntityId(cacheKey);
+    return region.getKeysFactory().getEntityId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/NonStrictReadWriteRedisNaturalIdRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/NonStrictReadWriteRedisNaturalIdRegionAccessStrategy.java
@@ -46,12 +46,12 @@ public class NonStrictReadWriteRedisNaturalIdRegionAccessStrategy
 
   @Override
   public Object generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SessionImplementor session) {
-    return DefaultCacheKeysFactory.INSTANCE.createNaturalIdKey(naturalIdValues, persister, session);
+    return region.getKeysFactory().createNaturalIdKey(naturalIdValues, persister, session);
   }
 
   @Override
   public Object[] getNaturalIdValues(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getNaturalIdValues(cacheKey);
+    return this.region.getKeysFactory().getNaturalIdValues(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadOnlyRedisCollectionRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadOnlyRedisCollectionRegionAccessStrategy.java
@@ -48,12 +48,12 @@ public class ReadOnlyRedisCollectionRegionAccessStrategy
                                  CollectionPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createCollectionKey(id, persister, factory, tenantIdentifier);
+    return region.getKeysFactory().createCollectionKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getCollectionId(cacheKey);
+    return region.getKeysFactory().getCollectionId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadOnlyRedisEntityRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadOnlyRedisEntityRegionAccessStrategy.java
@@ -48,7 +48,7 @@ public class ReadOnlyRedisEntityRegionAccessStrategy
                                  EntityPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createEntityKey(id, persister, factory, tenantIdentifier);
+    return region.getKeysFactory().createEntityKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadOnlyRedisNaturalIdRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadOnlyRedisNaturalIdRegionAccessStrategy.java
@@ -46,12 +46,12 @@ public class ReadOnlyRedisNaturalIdRegionAccessStrategy
   public Object generateCacheKey(Object[] naturalIdValues,
                                  EntityPersister persister,
                                  SessionImplementor session) {
-    return DefaultCacheKeysFactory.INSTANCE.createNaturalIdKey(naturalIdValues, persister, session);
+    return region.getKeysFactory().createNaturalIdKey(naturalIdValues, persister, session);
   }
 
   @Override
   public Object[] getNaturalIdValues(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getNaturalIdValues(cacheKey);
+    return region.getKeysFactory().getNaturalIdValues(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadWriteRedisCollectionRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadWriteRedisCollectionRegionAccessStrategy.java
@@ -46,12 +46,12 @@ public class ReadWriteRedisCollectionRegionAccessStrategy
                                  CollectionPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createCollectionKey(id, persister, factory, tenantIdentifier);
+    return region.getKeysFactory().createCollectionKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getCollectionId(cacheKey);
+    return region.getKeysFactory().getCollectionId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadWriteRedisEntityRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadWriteRedisEntityRegionAccessStrategy.java
@@ -51,12 +51,12 @@ public class ReadWriteRedisEntityRegionAccessStrategy
                                  EntityPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createEntityKey(id, persister, factory, tenantIdentifier);
+    return region.getKeysFactory().createEntityKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getEntityId(cacheKey);
+    return region.getKeysFactory().getEntityId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadWriteRedisNaturalIdRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/ReadWriteRedisNaturalIdRegionAccessStrategy.java
@@ -49,12 +49,12 @@ public class ReadWriteRedisNaturalIdRegionAccessStrategy
   public Object generateCacheKey(Object[] naturalIdValues,
                                  EntityPersister persister,
                                  SessionImplementor session) {
-    return DefaultCacheKeysFactory.INSTANCE.createNaturalIdKey(naturalIdValues, persister, session);
+    return region.getKeysFactory().createNaturalIdKey(naturalIdValues, persister, session);
   }
 
   @Override
   public Object[] getNaturalIdValues(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getNaturalIdValues(cacheKey);
+    return region.getKeysFactory().getNaturalIdValues(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/TransactionalRedisCollectionRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/TransactionalRedisCollectionRegionAccessStrategy.java
@@ -54,12 +54,12 @@ public class TransactionalRedisCollectionRegionAccessStrategy
                                  CollectionPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createCollectionKey(id, persister, factory, tenantIdentifier);
+    return region.getKeysFactory().createCollectionKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getCollectionId(cacheKey);
+    return region.getKeysFactory().getCollectionId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/TransactionalRedisEntityRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/TransactionalRedisEntityRegionAccessStrategy.java
@@ -54,12 +54,12 @@ public class TransactionalRedisEntityRegionAccessStrategy
                                  EntityPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createEntityKey(id, persister, factory, tenantIdentifier);
+    return region.getKeysFactory().createEntityKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getEntityId(cacheKey);
+    return region.getKeysFactory().getEntityId(cacheKey);
   }
 
   @Override

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/TransactionalRedisNaturalIdRegionAccessStrategy.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/strategy/TransactionalRedisNaturalIdRegionAccessStrategy.java
@@ -66,12 +66,12 @@ public class TransactionalRedisNaturalIdRegionAccessStrategy
   public Object generateCacheKey(Object[] naturalIdValues,
                                  EntityPersister persister,
                                  SessionImplementor session) {
-    return DefaultCacheKeysFactory.INSTANCE.createNaturalIdKey(naturalIdValues, persister, session);
+    return region.getKeysFactory().createNaturalIdKey(naturalIdValues, persister, session);
   }
 
   @Override
   public Object[] getNaturalIdValues(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getNaturalIdValues(cacheKey);
+    return region.getKeysFactory().getNaturalIdValues(cacheKey);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/AbstractRedisRegionFactory.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/AbstractRedisRegionFactory.java
@@ -30,6 +30,9 @@ import org.hibernate.cache.redis.util.RedisCacheUtil;
 import org.hibernate.cache.redis.util.Timestamper;
 import org.hibernate.cache.spi.*;
 import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.internal.SimpleCacheKeysFactory;
+import org.hibernate.cfg.Environment;
 import org.redisson.config.Config;
 
 import java.util.Properties;
@@ -53,8 +56,38 @@ public abstract class AbstractRedisRegionFactory implements RegionFactory, Confi
   protected volatile RedisClient redis = null;
   protected CacheTimestamper cacheTimestamper = null;
 
+  protected CacheKeysFactory cacheKeysFactory = null;
+
   protected AbstractRedisRegionFactory(@NonNull Properties props) {
     this.props = props;
+    prepareCacheKeysFactory(props);
+  }
+
+  /**
+   * Query properties for {@link Environment#CACHE_KEYS_FACTORY} definition in order to
+   * support more than {@link DefaultCacheKeysFactory}. If no definition is found or there
+   * is a problem with the implementation class {@link DefaultCacheKeysFactory#INSTANCE} is
+   * set as default.
+   *
+   * @param props Properties where to search and set for the custom implementation of CacheKeysFactory
+   */
+  private void prepareCacheKeysFactory(Properties props) {
+    String factoryName = props.getProperty(Environment.CACHE_KEYS_FACTORY, null);
+    if (factoryName == null || "default".equalsIgnoreCase(factoryName)){
+      cacheKeysFactory = DefaultCacheKeysFactory.INSTANCE;
+      return;
+    }
+    if ("simple".equalsIgnoreCase(factoryName)){
+      cacheKeysFactory = SimpleCacheKeysFactory.INSTANCE;
+    }
+    try {
+      Class<?> clazz = Class.forName(factoryName);
+      if (CacheKeysFactory.class.isAssignableFrom(CacheKeysFactory.class)){
+        cacheKeysFactory = (CacheKeysFactory) clazz.newInstance();
+      }
+    }catch (Throwable t){
+      log.warn("CacheKeysFactory class {} can't be instantiated. Defaulting to DefaultCacheKeysFactory", factoryName);
+    }
   }
 
   @Override
@@ -94,7 +127,7 @@ public abstract class AbstractRedisRegionFactory implements RegionFactory, Confi
                                  regionName,
                                  options,
                                  metadata,
-                                 properties);
+                                 properties, cacheKeysFactory);
   }
 
   @Override
@@ -107,7 +140,7 @@ public abstract class AbstractRedisRegionFactory implements RegionFactory, Confi
                                     regionName,
                                     options,
                                     metadata,
-                                    properties);
+                                    properties, cacheKeysFactory);
   }
 
   @Override
@@ -120,7 +153,7 @@ public abstract class AbstractRedisRegionFactory implements RegionFactory, Confi
                                      regionName,
                                      options,
                                      metadata,
-                                     properties);
+                                     properties, cacheKeysFactory);
   }
 
   @Override
@@ -130,7 +163,7 @@ public abstract class AbstractRedisRegionFactory implements RegionFactory, Confi
                                        redis,
                                        this,
                                        regionName,
-                                       properties);
+                                       properties, cacheKeysFactory);
   }
 
   @Override
@@ -140,7 +173,7 @@ public abstract class AbstractRedisRegionFactory implements RegionFactory, Confi
                                      redis,
                                      this,
                                      regionName,
-                                     properties);
+                                     properties, cacheKeysFactory);
   }
 
   private static final long serialVersionUID = 4244155609146774509L;

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisCollectionRegion.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisCollectionRegion.java
@@ -25,7 +25,7 @@ import org.hibernate.cache.spi.CacheDataDescription;
 import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
-
+import org.hibernate.cache.spi.CacheKeysFactory;
 import java.util.Properties;
 
 /**
@@ -42,8 +42,8 @@ public class RedisCollectionRegion extends RedisTransactionalDataRegion implemen
                                String regionName,
                                SessionFactoryOptions options,
                                CacheDataDescription metadata,
-                               Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, options, metadata, props);
+                               Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, options, metadata, props, cacheKeysFactory);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisDataRegion.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisDataRegion.java
@@ -25,6 +25,7 @@ import org.hibernate.cache.redis.hibernate52.strategy.RedisAccessStrategyFactory
 import org.hibernate.cache.redis.util.CacheTimestamper;
 import org.hibernate.cache.redis.util.RedisCacheUtil;
 import org.hibernate.cache.spi.Region;
+import org.hibernate.cache.spi.CacheKeysFactory;
 
 import java.util.Map;
 import java.util.Properties;
@@ -57,15 +58,18 @@ public abstract class RedisDataRegion implements Region {
   @Getter
   private final int expiryInSeconds;  // seconds
 
+  @Getter
+  private final CacheKeysFactory cacheKeysFactory;
+
   public RedisDataRegion(RedisAccessStrategyFactory accessStrategyFactory,
                          RedisClient redis, ConfigurableRedisRegionFactory configurableRedisRegionFactory,
                          String regionName,
-                         Properties props) {
+                         Properties props, CacheKeysFactory cacheKeysFactory) {
     this.accessStrategyFactory = accessStrategyFactory;
     this.redis = redis;
     this.regionName = regionName;
     this.cacheTimestamper = configurableRedisRegionFactory.createCacheTimestamper(redis, regionName);
-
+    this.cacheKeysFactory = cacheKeysFactory;
     this.expiryInSeconds = RedisCacheUtil.getExpiryInSeconds(this.regionName);
     log.debug("redis region={}, expiryInSeconds={}", regionName, expiryInSeconds);
   }

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisEntityRegion.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisEntityRegion.java
@@ -26,7 +26,7 @@ import org.hibernate.cache.spi.CacheDataDescription;
 import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
-
+import org.hibernate.cache.spi.CacheKeysFactory;
 import java.util.Properties;
 
 /**
@@ -43,8 +43,8 @@ public class RedisEntityRegion extends RedisTransactionalDataRegion implements E
                            String regionName,
                            SessionFactoryOptions options,
                            CacheDataDescription metadata,
-                           Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, options, metadata, props);
+                           Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, options, metadata, props, cacheKeysFactory);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisGeneralDataRegion.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisGeneralDataRegion.java
@@ -23,7 +23,7 @@ import org.hibernate.cache.redis.hibernate52.ConfigurableRedisRegionFactory;
 import org.hibernate.cache.redis.hibernate52.strategy.RedisAccessStrategyFactory;
 import org.hibernate.cache.spi.GeneralDataRegion;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-
+import org.hibernate.cache.spi.CacheKeysFactory;
 import java.util.Properties;
 
 /**
@@ -38,8 +38,8 @@ public class RedisGeneralDataRegion extends RedisDataRegion implements GeneralDa
   public RedisGeneralDataRegion(RedisAccessStrategyFactory accessStrategyFactory,
                                 RedisClient redis, ConfigurableRedisRegionFactory configurableRedisRegionFactory,
                                 String regionName,
-                                Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props);
+                                Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props, cacheKeysFactory);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisNaturalIdRegion.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisNaturalIdRegion.java
@@ -26,7 +26,7 @@ import org.hibernate.cache.spi.CacheDataDescription;
 import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
-
+import org.hibernate.cache.spi.CacheKeysFactory;
 import java.util.Properties;
 
 /**
@@ -43,8 +43,8 @@ public class RedisNaturalIdRegion extends RedisTransactionalDataRegion implement
                               String regionName,
                               SessionFactoryOptions options,
                               CacheDataDescription metadata,
-                              Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, options, metadata, props);
+                              Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, options, metadata, props, cacheKeysFactory);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisQueryResultsRegion.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisQueryResultsRegion.java
@@ -21,7 +21,7 @@ import org.hibernate.cache.redis.client.RedisClient;
 import org.hibernate.cache.redis.hibernate52.ConfigurableRedisRegionFactory;
 import org.hibernate.cache.redis.hibernate52.strategy.RedisAccessStrategyFactory;
 import org.hibernate.cache.spi.QueryResultsRegion;
-
+import org.hibernate.cache.spi.CacheKeysFactory;
 import java.util.Properties;
 
 /**
@@ -36,7 +36,7 @@ public class RedisQueryResultsRegion extends RedisGeneralDataRegion implements Q
   public RedisQueryResultsRegion(RedisAccessStrategyFactory accessStrategyFactory,
                                  RedisClient redis, ConfigurableRedisRegionFactory configurableRedisRegionFactory,
                                  String regionName,
-                                 Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props);
+                                 Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props, cacheKeysFactory);
   }
 }

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisTimestampsRegion.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisTimestampsRegion.java
@@ -21,7 +21,7 @@ import org.hibernate.cache.redis.client.RedisClient;
 import org.hibernate.cache.redis.hibernate52.ConfigurableRedisRegionFactory;
 import org.hibernate.cache.redis.hibernate52.strategy.RedisAccessStrategyFactory;
 import org.hibernate.cache.spi.TimestampsRegion;
-
+import org.hibernate.cache.spi.CacheKeysFactory;
 import java.util.Properties;
 
 /**
@@ -36,7 +36,7 @@ public class RedisTimestampsRegion extends RedisGeneralDataRegion implements Tim
   public RedisTimestampsRegion(RedisAccessStrategyFactory accessStrategyFactory,
                                RedisClient redis, ConfigurableRedisRegionFactory configurableRedisRegionFactory,
                                String regionName,
-                               Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props);
+                               Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props, cacheKeysFactory);
   }
 }

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisTransactionalDataRegion.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/regions/RedisTransactionalDataRegion.java
@@ -25,7 +25,7 @@ import org.hibernate.cache.redis.hibernate52.ConfigurableRedisRegionFactory;
 import org.hibernate.cache.redis.hibernate52.strategy.RedisAccessStrategyFactory;
 import org.hibernate.cache.spi.CacheDataDescription;
 import org.hibernate.cache.spi.TransactionalDataRegion;
-
+import org.hibernate.cache.spi.CacheKeysFactory;
 import java.util.Properties;
 
 /**
@@ -51,8 +51,8 @@ public class RedisTransactionalDataRegion extends RedisDataRegion implements Tra
                                       String regionName,
                                       SessionFactoryOptions options,
                                       CacheDataDescription metadata,
-                                      Properties props) {
-    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props);
+                                      Properties props, CacheKeysFactory cacheKeysFactory) {
+    super(accessStrategyFactory, redis, configurableRedisRegionFactory, regionName, props, cacheKeysFactory);
 
     this.options = options;
     this.metadata = metadata;

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/NonStrictReadWriteRedisCollectionRegionAccessStrategy.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/NonStrictReadWriteRedisCollectionRegionAccessStrategy.java
@@ -49,12 +49,12 @@ public class NonStrictReadWriteRedisCollectionRegionAccessStrategy
                                  CollectionPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createCollectionKey(id, persister, factory, tenantIdentifier);
+    return region.getCacheKeysFactory().createCollectionKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getCollectionId(cacheKey);
+    return region.getCacheKeysFactory().getCollectionId(cacheKey);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/NonStrictReadWriteRedisEntityRegionAccessStrategy.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/NonStrictReadWriteRedisEntityRegionAccessStrategy.java
@@ -47,12 +47,12 @@ public class NonStrictReadWriteRedisEntityRegionAccessStrategy
                                  EntityPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createEntityKey(id, persister, factory, tenantIdentifier);
+    return region.getCacheKeysFactory().createEntityKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getEntityId(cacheKey);
+    return region.getCacheKeysFactory().getEntityId(cacheKey);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/NonStrictReadWriteRedisNaturalIdRegionAccessStrategy.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/NonStrictReadWriteRedisNaturalIdRegionAccessStrategy.java
@@ -48,12 +48,12 @@ public class NonStrictReadWriteRedisNaturalIdRegionAccessStrategy
   public Object generateCacheKey(Object[] naturalIdValues,
                                  EntityPersister persister,
                                  SharedSessionContractImplementor session) {
-    return DefaultCacheKeysFactory.INSTANCE.createNaturalIdKey(naturalIdValues, persister, session);
+    return region.getCacheKeysFactory().createNaturalIdKey(naturalIdValues, persister, session);
   }
 
   @Override
   public Object[] getNaturalIdValues(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getNaturalIdValues(cacheKey);
+    return region.getCacheKeysFactory().getNaturalIdValues(cacheKey);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/ReadOnlyRedisCollectionRegionAccessStrategy.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/ReadOnlyRedisCollectionRegionAccessStrategy.java
@@ -48,12 +48,12 @@ public class ReadOnlyRedisCollectionRegionAccessStrategy
                                  CollectionPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createCollectionKey(id, persister, factory, tenantIdentifier);
+    return region.getCacheKeysFactory().createCollectionKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getCollectionId(cacheKey);
+    return region.getCacheKeysFactory().getCollectionId(cacheKey);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/ReadOnlyRedisEntityRegionAccessStrategy.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/ReadOnlyRedisEntityRegionAccessStrategy.java
@@ -18,7 +18,6 @@ package org.hibernate.cache.redis.hibernate52.strategy;
 
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.boot.spi.SessionFactoryOptions;
-import org.hibernate.cache.internal.DefaultCacheKeysFactory;
 import org.hibernate.cache.redis.hibernate52.regions.RedisEntityRegion;
 import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
@@ -48,7 +47,7 @@ public class ReadOnlyRedisEntityRegionAccessStrategy
                                  EntityPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.staticCreateEntityKey(id, persister, factory, tenantIdentifier);
+    return region.getCacheKeysFactory().createEntityKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/ReadOnlyRedisNaturalIdRegionAccessStrategy.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/ReadOnlyRedisNaturalIdRegionAccessStrategy.java
@@ -46,12 +46,12 @@ public class ReadOnlyRedisNaturalIdRegionAccessStrategy
   public Object generateCacheKey(Object[] naturalIdValues,
                                  EntityPersister persister,
                                  SharedSessionContractImplementor session) {
-    return DefaultCacheKeysFactory.INSTANCE.createNaturalIdKey(naturalIdValues, persister, session);
+    return region.getCacheKeysFactory().createNaturalIdKey(naturalIdValues, persister, session);
   }
 
   @Override
   public Object[] getNaturalIdValues(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getNaturalIdValues(cacheKey);
+    return region.getCacheKeysFactory().getNaturalIdValues(cacheKey);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/ReadWriteRedisCollectionRegionAccessStrategy.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/ReadWriteRedisCollectionRegionAccessStrategy.java
@@ -46,12 +46,12 @@ public class ReadWriteRedisCollectionRegionAccessStrategy
                                  CollectionPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createCollectionKey(id, persister, factory, tenantIdentifier);
+    return region.getCacheKeysFactory().createCollectionKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getCollectionId(cacheKey);
+    return region.getCacheKeysFactory().getCollectionId(cacheKey);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/ReadWriteRedisEntityRegionAccessStrategy.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/ReadWriteRedisEntityRegionAccessStrategy.java
@@ -51,12 +51,12 @@ public class ReadWriteRedisEntityRegionAccessStrategy
                                  EntityPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createEntityKey(id, persister, factory, tenantIdentifier);
+    return region.getCacheKeysFactory().createEntityKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getEntityId(cacheKey);
+    return region.getCacheKeysFactory().getEntityId(cacheKey);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/ReadWriteRedisNaturalIdRegionAccessStrategy.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/ReadWriteRedisNaturalIdRegionAccessStrategy.java
@@ -49,12 +49,12 @@ public class ReadWriteRedisNaturalIdRegionAccessStrategy
   public Object generateCacheKey(Object[] naturalIdValues,
                                  EntityPersister persister,
                                  SharedSessionContractImplementor session) {
-    return DefaultCacheKeysFactory.INSTANCE.createNaturalIdKey(naturalIdValues, persister, session);
+    return region.getCacheKeysFactory().createNaturalIdKey(naturalIdValues, persister, session);
   }
 
   @Override
   public Object[] getNaturalIdValues(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getNaturalIdValues(cacheKey);
+    return region.getCacheKeysFactory().getNaturalIdValues(cacheKey);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/TransactionalRedisCollectionRegionAccessStrategy.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/TransactionalRedisCollectionRegionAccessStrategy.java
@@ -54,12 +54,12 @@ public class TransactionalRedisCollectionRegionAccessStrategy
                                  CollectionPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createCollectionKey(id, persister, factory, tenantIdentifier);
+    return region.getCacheKeysFactory().createCollectionKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getCollectionId(cacheKey);
+    return region.getCacheKeysFactory().getCollectionId(cacheKey);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/TransactionalRedisEntityRegionAccessStrategy.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/TransactionalRedisEntityRegionAccessStrategy.java
@@ -54,12 +54,12 @@ public class TransactionalRedisEntityRegionAccessStrategy
                                  EntityPersister persister,
                                  SessionFactoryImplementor factory,
                                  String tenantIdentifier) {
-    return DefaultCacheKeysFactory.INSTANCE.createEntityKey(id, persister, factory, tenantIdentifier);
+    return region.getCacheKeysFactory().createEntityKey(id, persister, factory, tenantIdentifier);
   }
 
   @Override
   public Object getCacheKeyId(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getEntityId(cacheKey);
+    return region.getCacheKeysFactory().getEntityId(cacheKey);
   }
 
   @Override

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/TransactionalRedisNaturalIdRegionAccessStrategy.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/strategy/TransactionalRedisNaturalIdRegionAccessStrategy.java
@@ -66,12 +66,12 @@ public class TransactionalRedisNaturalIdRegionAccessStrategy
   public Object generateCacheKey(Object[] naturalIdValues,
                                  EntityPersister persister,
                                  SharedSessionContractImplementor session) {
-    return DefaultCacheKeysFactory.INSTANCE.createNaturalIdKey(naturalIdValues, persister, session);
+    return region.getCacheKeysFactory().createNaturalIdKey(naturalIdValues, persister, session);
   }
 
   @Override
   public Object[] getNaturalIdValues(Object cacheKey) {
-    return DefaultCacheKeysFactory.INSTANCE.getNaturalIdValues(cacheKey);
+    return region.getCacheKeysFactory().getNaturalIdValues(cacheKey);
   }
 
   @Override


### PR DESCRIPTION
 Implementing CacheKeysFactory functionality in hibernate 5.x and 5.2. This PR will implement functionality based on hibernate specification as described in issue-126.