### PR TITLE
small bug in region factory hibernate-redis.properties was not loaded when java Config

### DIFF
--- a/hibernate4/src/main/java/org/hibernate/cache/redis/hibernate4/RedisRegionFactory.java
+++ b/hibernate4/src/main/java/org/hibernate/cache/redis/hibernate4/RedisRegionFactory.java
@@ -43,7 +43,9 @@ public class RedisRegionFactory extends AbstractRedisRegionFactory {
     try {
       if (redis == null) {
         RedisCacheUtil.loadCacheProperties(properties);
-        this.redis = createRedisClient();
+        this.redis = (RedisCacheUtil.getRedissonJavaConfig() != null) ?
+            createRedisClient(RedisCacheUtil.getRedissonJavaConfig()) :
+            createRedisClient();
         this.cacheTimestamper = createCacheTimestamper(redis, RedisRegionFactory.class.getName());
       }
       log.info("RedisRegionFactory is started");

--- a/hibernate4/src/main/java/org/hibernate/cache/redis/hibernate4/SingletonRedisRegionFactory.java
+++ b/hibernate4/src/main/java/org/hibernate/cache/redis/hibernate4/SingletonRedisRegionFactory.java
@@ -51,7 +51,8 @@ public class SingletonRedisRegionFactory extends AbstractRedisRegionFactory {
         this.redis = (nonNull(RedisCacheUtil.getRedissonJavaConfig())) ?
                 createRedisClient(RedisCacheUtil.getRedissonJavaConfig()) :
                 createRedisClient();
-	    this.cacheTimestamper = createCacheTimestamper(redis, SingletonRedisRegionFactory.class.getName());
+	      this.cacheTimestamper = createCacheTimestamper(redis, SingletonRedisRegionFactory.class.getName());
+	      RedisCacheUtil.saveRedisSingletonClient(redis);
       }
       ReferenceCount.incrementAndGet();
       log.info("Started SingletonRedisRegionFactory");

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/RedisRegionFactory.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/RedisRegionFactory.java
@@ -16,13 +16,12 @@
 
 package org.hibernate.cache.redis.hibernate5;
 
+import java.util.Properties;
 import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.redis.util.RedisCacheUtil;
-
-import java.util.Properties;
 
 /**
  * Hibernate 5.x 2nd Cache Region Factory using Redis
@@ -45,7 +44,9 @@ public class RedisRegionFactory extends AbstractRedisRegionFactory {
     try {
       if (redis == null) {
         RedisCacheUtil.loadCacheProperties(props);
-        this.redis = createRedisClient();
+        this.redis = (RedisCacheUtil.getRedissonJavaConfig() != null) ?
+            createRedisClient(RedisCacheUtil.getRedissonJavaConfig()) :
+            createRedisClient();
         this.cacheTimestamper = createCacheTimestamper(redis, RedisRegionFactory.class.getName());
       }
       log.info("RedisRegionFactory is started.");

--- a/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/SingletonRedisRegionFactory.java
+++ b/hibernate5/src/main/java/org/hibernate/cache/redis/hibernate5/SingletonRedisRegionFactory.java
@@ -16,16 +16,14 @@
 
 package org.hibernate.cache.redis.hibernate5;
 
-import static java.util.Objects.nonNull;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.NonNull;
 import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.redis.util.RedisCacheUtil;
-
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Singleton Hibernate 5.x 2nd Cache Region Factory using Redis
@@ -53,10 +51,11 @@ public class SingletonRedisRegionFactory extends AbstractRedisRegionFactory {
     try {
       if (redis == null) {
         RedisCacheUtil.loadCacheProperties(properties);
-        this.redis = (nonNull(RedisCacheUtil.getRedissonJavaConfig())) ?
-		     createRedisClient(RedisCacheUtil.getRedissonJavaConfig()) :
-		     createRedisClient();
-         this.cacheTimestamper = createCacheTimestamper(redis, SingletonRedisRegionFactory.class.getName());
+        this.redis = (RedisCacheUtil.getRedissonJavaConfig() != null) ?
+            createRedisClient(RedisCacheUtil.getRedissonJavaConfig()) :
+            createRedisClient();
+        this.cacheTimestamper = createCacheTimestamper(redis, SingletonRedisRegionFactory.class.getName());
+        RedisCacheUtil.saveRedisSingletonClient(redis);
       }
       referenceCount.incrementAndGet();
       log.info("RedisRegionFactory is started.");

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/RedisRegionFactory.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/RedisRegionFactory.java
@@ -45,7 +45,9 @@ public class RedisRegionFactory extends AbstractRedisRegionFactory {
     try {
       if (redis == null) {
         RedisCacheUtil.loadCacheProperties(props);
-        this.redis = createRedisClient();
+        this.redis = (RedisCacheUtil.getRedissonJavaConfig() != null) ?
+            createRedisClient(RedisCacheUtil.getRedissonJavaConfig()) :
+            createRedisClient();
         this.cacheTimestamper = createCacheTimestamper(redis, RedisRegionFactory.class.getName());
       }
       log.info("RedisRegionFactory is started.");

--- a/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/SingletonRedisRegionFactory.java
+++ b/hibernate52/src/main/java/org/hibernate/cache/redis/hibernate52/SingletonRedisRegionFactory.java
@@ -56,7 +56,8 @@ public class SingletonRedisRegionFactory extends AbstractRedisRegionFactory {
         this.redis = (nonNull(RedisCacheUtil.getRedissonJavaConfig())) ?
                 createRedisClient(RedisCacheUtil.getRedissonJavaConfig()) :
                 createRedisClient();
-	    this.cacheTimestamper = createCacheTimestamper(redis, SingletonRedisRegionFactory.class.getName());
+	      this.cacheTimestamper = createCacheTimestamper(redis, SingletonRedisRegionFactory.class.getName());
+	      RedisCacheUtil.saveRedisSingletonClient(this.redis);
       }
       if (redis != null)
         referenceCount.incrementAndGet();


### PR DESCRIPTION
hibernate-redis.properties were not loaded when Redisson Config was loaded from java code. Allowing RedisCacheUtils to hold created RedisClient after singleton factory init to be accessed later and monitored